### PR TITLE
Simplify and clean up ninja-file

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -9,11 +9,7 @@ f_in = 16
 
 ## end of user definitions
 
-build_dir = build
-
-rule create-build-directory
-    description = Create the build directory
-    command = mkdir -p $out
+builddir = build
 
 # run the synthese to produce a JSON output
 rule synthesize
@@ -33,8 +29,7 @@ rule gen-pll
     description = Generate PLL settings file
     command = icepll -i $f_in -o 100 -m -f $out
 
-build $build_dir: create-build-directory
-build $build_dir/pll.v: gen-pll
-build $build_dir/$project.json: synthesize $top.v $build_dir/pll.v
-build $build_dir/$project.asc: place-n-route $build_dir/$project.json
-build $build_dir/$project.bin: pack $build_dir/$project.asc
+build $builddir/pll.v: gen-pll
+build $builddir/$project.json: synthesize $top.v $builddir/pll.v
+build $builddir/$project.asc: place-n-route $builddir/$project.json
+build $builddir/$project.bin: pack $builddir/$project.asc


### PR DESCRIPTION
Previously a custom variable for the build directory was used instead of the standard one (`$build_dir` vs `$builddir`). This caused the `.ninja_log` to be generated in the repository root instead of the `build/`-directory. Therefore this commit renames that variable.

Furthermore, this commit removes the `create-build-directory` rule and invocation of that rule, since ninja creates the necessary direc- tories by itself.